### PR TITLE
ci: move release trigger to release branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Publish release
 on:
   push:
     branches: 
-      - main
+      - release
 
 jobs:
   release:


### PR DESCRIPTION
Change target branch used to trigger public release: main -> release