### PR TITLE
fix: generate nodes function

### DIFF
--- a/packages/flower-core/src/CoreUtils.ts
+++ b/packages/flower-core/src/CoreUtils.ts
@@ -157,20 +157,22 @@ export const CoreUtils: CoreUtilitiesFunctions = {
     ),
 
   generateNodesForFlowerJson: (nodes) =>
-    nodes.map((e) => {
-      const rules = CoreUtils.makeRules(e.props.to ?? {})
-      const nextRules = getRulesExists(rules)
-      const children = e.props.data?.children
-      return {
-        nodeId: e.props.id,
-        nodeType: e.type.displayName || e.props.as || 'FlowerNode',
-        nodeTitle: get(e.props, 'data.title'),
-        children,
-        nextRules,
-        retain: e.props.retain,
-        disabled: e.props.disabled
-      }
-    }),
+    nodes
+      .filter((e) => !!get(e, 'props.id'))
+      .map((e) => {
+        const rules = CoreUtils.makeRules(e.props.to ?? {})
+        const nextRules = getRulesExists(rules)
+        const children = e.props.data?.children
+        return {
+          nodeId: e.props.id,
+          nodeType: e.type.displayName || e.props.as || 'FlowerNode',
+          nodeTitle: get(e.props, 'data.title'),
+          children,
+          nextRules,
+          retain: e.props.retain,
+          disabled: e.props.disabled
+        }
+      }),
 
   cleanPath: (name: string, char = '^') => trimStart(name, char),
 


### PR DESCRIPTION
## Description

Comments inserted alongside React components were causing a crash as they were being interpreted as empty strings.
This was due to the lack of a filter on the nodes received as input by the function that generates the nodes for `FlowerJson`.


## List of proposed changes

<!-- Summarize the changes in list format -->
1) The function **generateNodesForFlowerJson** within **CoreUtils** has been updated to include a filter on the nodes, selecting only those that have an **id** field among the props.

## How to test the changes

<!-- If your changes require a specific way to test them, write here the steps -->
The actual functionality can be tested by inserting a comment alongside a React component.
```code
  <FlowerRoute id="test" to={{ start: null }} /> {/*test_comment*/ }
```

## Modified packages 
- [x] flower-core
- [ ] flower-react
- [ ] flower-demo
