### PR TITLE
Update repo versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6352,7 +6352,7 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -6367,7 +6367,7 @@
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -13242,23 +13242,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      }
-    },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -13289,24 +13272,6 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jest-circus/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/jest-circus/node_modules/dedent": {
       "version": "1.5.3",
@@ -18092,16 +18057,6 @@
         }
       }
     },
-    "node_modules/react-refresh": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
-      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "dev": true,
@@ -22183,7 +22138,7 @@
     },
     "packages/flower-core": {
       "name": "@flowerforce/flower-core",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
         "flat": "5.0.2",
@@ -22293,7 +22248,7 @@
       "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@flowerforce/flower-core": "3.1.0",
+        "@flowerforce/flower-core": "3.1.1",
         "@reduxjs/toolkit": "^2.2.4",
         "lodash": "^4.17.21",
         "react-redux": "^9.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6352,7 +6352,7 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -6367,7 +6367,7 @@
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -13242,6 +13242,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -13272,6 +13289,24 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jest-circus/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/jest-circus/node_modules/dedent": {
       "version": "1.5.3",
@@ -18055,6 +18090,16 @@
         "redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/read-cache": {

--- a/packages/flower-core/CHANGELOG.md
+++ b/packages/flower-core/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.1.1 (2024-06-11)
+
+
+### 🩹 Fixes
+
+- generate nodes function ([952c58d](https://github.com/flowerforce/flower/commit/952c58d))
+
 ## 3.1.0 (2024-06-06)
 
 

--- a/packages/flower-core/package.json
+++ b/packages/flower-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowerforce/flower-core",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Core functions for flowerJS",
   "repository": {
     "type": "git",

--- a/packages/flower-react/README.md
+++ b/packages/flower-react/README.md
@@ -59,6 +59,7 @@ function Root() {
   )
 }
 ```
+> You can pass the prop `enableReduxDevtool` to the `FlowerProvider` to show the Flower Store data inside the redux devtool of your browser.
 
 ## How to use
 

--- a/packages/flower-react/package.json
+++ b/packages/flower-react/package.json
@@ -34,7 +34,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@flowerforce/flower-core": "3.1.0",
+    "@flowerforce/flower-core": "3.1.1",
     "@reduxjs/toolkit": "^2.2.4",
     "lodash": "^4.17.21",
     "react-redux": "^9.1.2",

--- a/packages/flower-react/src/provider.tsx
+++ b/packages/flower-react/src/provider.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, Component, createContext } from 'react'
+import React, { PropsWithChildren, createContext, PureComponent } from 'react'
 import {
   Provider,
   createDispatchHook,
@@ -26,11 +26,14 @@ export const store = ({ enableDevtool }: { enableDevtool?: boolean }) =>
     devTools: enableDevtool ? { name: 'flower' } : false
   })
 
-class FlowerProvider extends Component<PropsWithChildren, FlowerProviderProps> {
+class FlowerProvider extends PureComponent<
+  PropsWithChildren<{ enableReduxDevtool?: boolean }>,
+  FlowerProviderProps
+> {
   private store: FlowerProviderProps
-  constructor(props: PropsWithChildren & { enableDevtool?: boolean }) {
+  constructor(props: PropsWithChildren<{ enableReduxDevtool?: boolean }>) {
     super(props)
-    this.store = store({ enableDevtool: props.enableDevtool })
+    this.store = store({ enableDevtool: props.enableReduxDevtool })
   }
 
   render() {


### PR DESCRIPTION
## Description

The functionality that allows adding the data from the flower store to the Redux Devtool extension has been fixed.

## List of proposed changes

1.  Now you can pass the `enableReduxDevtool` prop to the `FlowerProvider` component in order to add the Flower Store to the Redux Devtool.

## How to test the changes

<!-- If your changes require a specific way to test them, write here the steps -->
1. Create a demo project with the FlowerProvider
2. Pass the enableReduxDevtool prop to the FlowerProvider
3. Open the Redux Devtools in your browser
4. Now you can see the data from the flower store

## Modified packages 
- [ ] flower-core
- [x] flower-react
- [ ] flower-demo
