### PR TITLE
Merge `release` into `main`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6352,7 +6352,7 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -6367,7 +6367,7 @@
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -13242,23 +13242,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      }
-    },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -13289,24 +13272,6 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jest-circus/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/jest-circus/node_modules/dedent": {
       "version": "1.5.3",
@@ -18092,16 +18057,6 @@
         }
       }
     },
-    "node_modules/react-refresh": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
-      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "dev": true,
@@ -22206,7 +22161,7 @@
       "license": "ISC",
       "dependencies": {
         "@flowerforce/devtool": "^3.0.6",
-        "@flowerforce/flower-react": "3.1.0",
+        "@flowerforce/flower-react": "3.1.1",
         "@reduxjs/toolkit": "^2.2.4",
         "antd": "^5.17.2",
         "lodash": "^4.17.21",
@@ -22290,7 +22245,7 @@
     },
     "packages/flower-react": {
       "name": "@flowerforce/flower-react",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
         "@flowerforce/flower-core": "3.1.1",

--- a/packages/flower-demo/package.json
+++ b/packages/flower-demo/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@flowerforce/flower-react": "3.1.0",
+    "@flowerforce/flower-react": "3.1.1",
     "@flowerforce/devtool": "^3.0.6",
     "@reduxjs/toolkit": "^2.2.4",
     "antd": "^5.17.2",

--- a/packages/flower-react/CHANGELOG.md
+++ b/packages/flower-react/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.1.1 (2024-06-11)
+
+
+### 🩹 Fixes
+
+- enableReduxDevtool prop inside FlowerProvider ([ff0e57a](https://github.com/flowerforce/flower/commit/ff0e57a))
+
 ## 3.1.0 (2024-06-06)
 
 

--- a/packages/flower-react/package.json
+++ b/packages/flower-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowerforce/flower-react",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "FlowerJS components, hooks and utils for React.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Merges `release` into `main` to keep the branches aligned.

The last published version of `flower-react` is `3.1.1`, however the version on main is not updated. This is probably due to a problem in the last release workflow, with the new version being published to npm but not updated on the main branch.

> [!NOTE]
> This problem should no longer happen with the new ruleset on main and #31.

## Modified packages 
- [ ] flower-core
- [x] flower-react
- [x] flower-demo
