### PR TITLE
fix: (REACT) add layout prop to Flower

### DIFF
--- a/packages/flower-react/src/components/Flower.tsx
+++ b/packages/flower-react/src/components/Flower.tsx
@@ -29,6 +29,7 @@ type FlowerClientProps = PropsWithChildren & {
   destroyOnUnmount?: boolean
   startId?: string | null
   initialData?: any
+  layout?: 'vertical' | 'horizontal'
 }
 
 /**
@@ -39,7 +40,8 @@ const FlowerClient = ({
   name,
   destroyOnUnmount = true,
   startId = null,
-  initialData = {}
+  initialData = {},
+  layout = 'vertical'
 }: FlowerClientProps) => {
   const flowName = name
 


### PR DESCRIPTION
## Description

Added layout prop to Flower component, needed to set flow direction in graphic tool

## List of proposed changes

<!-- Summarize the changes in list format -->

## How to test the changes

Try to use layout prop when invoking `<Flower />` in your code

## Modified packages 
- [ ] flower-core
- [x] flower-react
- [ ] flower-demo
