### PR TITLE
feat: insert hook to sync browser navigation | change some example in demo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "dependencies": {
         "majestic": "^1.8.1",
+        "react-dom": "^19.1.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -18879,6 +18880,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-dom": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -20840,6 +20853,12 @@
       "engines": {
         "node": ">=v12.22.7"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "4.3.0",
@@ -24039,6 +24058,31 @@
         "reselect": "^5.1.0"
       }
     },
+    "packages/flower-react-browser-navigation": {
+      "name": "@flowerforce/flower-react-browser-context",
+      "version": "4.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@flowerforce/flower-core": "4.0.1-beta.8",
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.4.5",
+        "@testing-library/react": "^15.0.7",
+        "@testing-library/user-event": "^14.5.2",
+        "@types/lodash": "^4.17.1",
+        "@types/react": "^18.3.2",
+        "@types/react-dom": "^18.3.0",
+        "typescript": "^5.4.5"
+      },
+      "peerDependencies": {
+        "@reduxjs/toolkit": "^2.2.4",
+        "react": ">=18",
+        "react-redux": "^9.1.2",
+        "reselect": "^5.1.0"
+      }
+    },
     "packages/flower-react-context": {
       "name": "@flowerforce/flower-react-context",
       "version": "4.0.1-beta.8",
@@ -24072,6 +24116,30 @@
         "@flowerforce/flower-react-context": "4.0.1-beta.8",
         "@flowerforce/flower-react-shared": "4.0.6-beta.4",
         "@flowerforce/flower-react-store": "4.0.1-beta.8",
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.4.5",
+        "@testing-library/react": "^15.0.7",
+        "@testing-library/user-event": "^14.5.2",
+        "@types/lodash": "^4.17.1",
+        "@types/react": "^18.3.2",
+        "@types/react-dom": "^18.3.0",
+        "typescript": "^5.4.5"
+      },
+      "peerDependencies": {
+        "@reduxjs/toolkit": "^2.2.4",
+        "react": ">=18",
+        "react-redux": "^9.1.2",
+        "reselect": "^5.1.0"
+      }
+    },
+    "packages/flower-react-history-context": {
+      "name": "@flowerforce/flower-react-history-context",
+      "version": "4.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
         "lodash": "^4.17.21"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "homepage": "https://www.flowerjs.it",
   "dependencies": {
     "majestic": "^1.8.1",
+    "react-dom": "^19.1.0",
     "tslib": "^2.3.0"
   },
   "devDependencies": {
@@ -70,6 +71,7 @@
     "@nx/rollup": "19.4.1",
     "@nx/webpack": "19.4.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
+    "@reduxjs/toolkit": "^2.2.4",
     "@svgr/webpack": "^8.0.1",
     "@swc-node/register": "~1.9.1",
     "@swc/cli": "~0.3.12",
@@ -94,17 +96,15 @@
     "markdownlint-cli2": "^0.15.0",
     "nx": "19.4.1",
     "prettier": "^3.2.5",
+    "react": ">=18",
+    "react-redux": "^9.1.2",
+    "reselect": "^5.1.0",
     "rimraf": "^5.0.7",
     "rollup": "^4.18.0",
     "ts-jest": "^29.1.4",
     "ts-node": "^10.9.2",
     "typescript": "~5.4.2",
-    "webpack-cli": "^5.1.4",
-    "react": ">=18",
-    "@reduxjs/toolkit": "^2.2.4",
-    "react-redux": "^9.1.2",
-    "reselect": "^5.1.0"
-
+    "webpack-cli": "^5.1.4"
   },
   "optionalDependencies": {
     "@nx/nx-darwin-arm64": "19.4.1",

--- a/packages/flower-demo/src/App.tsx
+++ b/packages/flower-demo/src/App.tsx
@@ -6,8 +6,8 @@ export function MainApp() {
   return (
     <div style={{ display: 'flex', justifyContent: 'space-between' }}>
       <AppFlow />
-      <AppForm />
-      <AppFlowWithCustomReducers />
+      {/* <AppForm /> */}
+      {/* <AppFlowWithCustomReducers /> */}
     </div>
   )
 }

--- a/packages/flower-demo/src/AppFlowWithCustomReducer.tsx
+++ b/packages/flower-demo/src/AppFlowWithCustomReducer.tsx
@@ -50,7 +50,7 @@ export function AppFlowWithCustomReducers() {
       style={{ display: 'flex', flexDirection: 'column', padding: '50px' }}
     >
       FLOW WITH EXTERNAL REDUCERS
-      <FlowerProvider<Record<string, any>> configureStore={config}>
+      <FlowerProvider configureStore={config}>
         <ExternalReducers />
       </FlowerProvider>
     </div>

--- a/packages/flower-demo/src/Examples/ExampleExternalReducers.tsx
+++ b/packages/flower-demo/src/Examples/ExampleExternalReducers.tsx
@@ -4,7 +4,6 @@ import {
   FlowerAction,
   useFlower,
   Flower,
-  useDispatch
 } from '@flowerforce/flower-react'
 import {
   FlowerForm,
@@ -16,6 +15,7 @@ import { FlowerValue } from '@flowerforce/flower-react-shared'
 import { useCallback, useEffect } from 'react'
 import './styles.css'
 import { actionsCustom1, actionsCustom2 } from '../AppFlowWithCustomReducer'
+import { useDispatch } from 'react-redux'
 
 const ButtonNext = () => {
   const { next } = useFlower()

--- a/packages/flower-react/src/components/hooks/useBrowserNavigationSync.ts
+++ b/packages/flower-react/src/components/hooks/useBrowserNavigationSync.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react'
+import { useFlowerActions } from '../../types'
+import { ReduxFlowerProvider } from '@flowerforce/flower-react-store'
+
+/**
+ * Hook centralizzato per sincronizzare la navigazione browser con Redux
+ * @param {function} backAction - Azione Redux da chiamare quando si fa "indietro"
+ * @param {function} nextAction - Azione Redux da chiamare quando si fa "avanti"
+ */
+
+type UseHistorySyncProps = {
+  indexRef: React.MutableRefObject<number>
+  backAction: () => ReturnType<useFlowerActions['back']>
+  nextAction: () => ReturnType<useFlowerActions['next']>
+}
+export const useHistorySync = ({
+  indexRef,
+  backAction,
+  nextAction
+}: UseHistorySyncProps) => {
+  const { dispatch } = ReduxFlowerProvider.getReduxHooks()
+
+  useEffect(() => {
+    // Inizializza lo stato nella history se non esiste
+    const initialIndex = window.history.state?.index ?? 0
+    indexRef.current = initialIndex
+    window.history.replaceState(
+      { index: initialIndex },
+      '',
+      window.location.pathname
+    )
+
+    const onPopState = (event: PopStateEvent) => {
+      const newIndex = event.state?.index ?? 0
+
+      if (newIndex > indexRef.current) {
+        indexRef.current = newIndex
+        nextAction()
+      } else if (newIndex < indexRef.current) {
+        indexRef.current = newIndex
+        backAction()
+      }
+    }
+
+    window.addEventListener('popstate', onPopState)
+    return () => window.removeEventListener('popstate', onPopState)
+  }, [dispatch, backAction, nextAction])
+
+
+}

--- a/packages/flower-react/src/components/useFlower/index.tsx
+++ b/packages/flower-react/src/components/useFlower/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from 'react'
+import { useCallback, useContext, useRef } from 'react'
 import { makeSelectStartNodeId, makeSelectCurrentNodeId } from '../../features'
 import { FlowerReactContext } from '@flowerforce/flower-react-context'
 import { ReduxFlowerProvider } from '@flowerforce/flower-react-store'
@@ -12,6 +12,7 @@ import {
   makeActionPayloadOnReset,
   makeActionPayloadOnRestart
 } from './utils'
+import { useHistorySync } from '../hooks/useBrowserNavigationSync'
 
 type NavigateFunctionParams = string | Record<string, any>
 
@@ -45,6 +46,8 @@ export const useFlower: UseFlower = ({
   const nodeId = useSelector(makeSelectCurrentNodeId(flowName ?? ''))
   const startId = useSelector(makeSelectStartNodeId(flowName ?? ''))
 
+  const indexRef = useRef(0)
+
   const emitNavigateEvent = useCallback(
     //TODO check this function is needed
     (params: any) => {
@@ -71,13 +74,16 @@ export const useFlower: UseFlower = ({
       const { type, payload } = makeActionPayloadOnNext(flowName, params)
       dispatch({
         type: `${REDUCER_NAME.FLOWER_FLOW}/${type}`,
-        payload: {
-          ...payload,
-          data: store.getState()
-        }
+        payload: { ...payload, data: store.getState() }
       })
 
       emitNavigateEvent({ type, payload })
+      indexRef.current += 1
+      window.history.replaceState(
+        { index: indexRef.current },
+        '',
+        window.location.pathname
+      )
     },
     [dispatch, emitNavigateEvent, flowName, store]
   )
@@ -85,7 +91,10 @@ export const useFlower: UseFlower = ({
   const back = useCallback(
     (param?: NavigateFunctionParams) => {
       const { type, payload } = makeActionPayloadOnBack(flowName, param)
-      dispatch({ type: `${REDUCER_NAME.FLOWER_FLOW}/${type}`, payload })
+      dispatch({
+        type: `${REDUCER_NAME.FLOWER_FLOW}/${type}`,
+        payload
+      })
 
       emitNavigateEvent({ type, payload })
     },
@@ -108,10 +117,7 @@ export const useFlower: UseFlower = ({
         flowName,
         typeof param === 'string'
           ? { node: param, initialData }
-          : {
-              ...param,
-              initialData
-            }
+          : { ...param, initialData }
       )
 
       dispatch({ type: `${REDUCER_NAME.FLOWER_FLOW}/${type}`, payload })
@@ -130,6 +136,8 @@ export const useFlower: UseFlower = ({
     },
     [dispatch, emitNavigateEvent, flowName]
   )
+  
+  useHistorySync({ indexRef, backAction: back, nextAction: next })
 
   const getCurrentNodeId = useCallback(
     (customFlowName?: string) => {


### PR DESCRIPTION
## Description

First attempt to insert browser navigation inside Flower process
For this first attempt, we decided to handle with a custom hook that mimic browser history and anchor flower actions to a listener for the popStateEvent

Nexts updates would be:
 - check if a listener already exists ( now custom history hook is called inside useFlower )
 - behaviour if we have different flows or a parent flow with other flows inside

## List of proposed changes

<!-- Summarize the changes in list format -->

## How to test the changes

<!-- If your changes require a specific way to test them, write here the steps -->

## Modified packages 
- [ ] flower-core
- [ ] flower-react
- [ ] flower-demo
- [ ] flower-devtool

